### PR TITLE
refactor: rename Google API key setting

### DIFF
--- a/src/brew_oracle/orchestrator/brewing_orchestrator.py
+++ b/src/brew_oracle/orchestrator/brewing_orchestrator.py
@@ -2,12 +2,14 @@
 from agno.agent import Agent
 from agno.models.google import Gemini
 from brew_oracle.knowledge.pdf_kb import build_pdf_kb
+from brew_oracle.utils.config import Settings
 
 class BrewingOrchestrator:
     def __init__(self, kb=None, model=None):
 
         self.kb = kb or build_pdf_kb()
-        self.model = model or Gemini(id="gemini-2.0-flash")  
+        s = Settings()
+        self.model = model or Gemini(id="gemini-2.0-flash", api_key=s.GOOGLE_API_KEY)
 
         self.agent = Agent(
             name="BrewingOrchestrator",

--- a/src/brew_oracle/utils/config.py
+++ b/src/brew_oracle/utils/config.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     TOP_K: int = Field(default=20)
 
-    GOOGLE_GENAI_API_KEY: str | None = None
+    GOOGLE_API_KEY: str | None = Field(default=None)
 
     model_config = SettingsConfigDict(
         env_file='.env',


### PR DESCRIPTION
## Summary
- rename setting GOOGLE_GENAI_API_KEY to GOOGLE_API_KEY
- inject API key into BrewingOrchestrator's Gemini model

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68961fef4a38832b84a8b4fbfd765964