### PR TITLE
Make embedder configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ Ele responde **usando a base de conhecimento indexada**, **cita as fontes** e ma
     GOOGLE_API_KEY=coloque_sua_chave_aqui
     ```
 
+    > 💡 Para usar outro modelo de embeddings, altere `EMBEDDER_ID` e `EMBEDDER_DIM`.
+    > `EMBEDDER_ID` pode ser um caminho local (ex.: `./models/meu-modelo`) ou o
+    > identificador do modelo no Hugging Face, e `EMBEDDER_DIM` deve refletir o
+    > tamanho do vetor produzido por ele.
+
 4. **(Opcional) Baixar o embedder localmente**
 
     ```bash

--- a/src/brew_oracle/knowledge/pdf_kb.py
+++ b/src/brew_oracle/knowledge/pdf_kb.py
@@ -11,8 +11,8 @@ def build_pdf_kb() -> PDFKnowledgeBase:
     os.makedirs(s.PDF_PATH, exist_ok=True)
 
     embedder = SentenceTransformerEmbedder(
-    id="./models/all-MiniLM-L6-v2",  
-    dimensions=384,
+        id=s.EMBEDDER_ID,
+        dimensions=s.EMBEDDER_DIM,
     )
 
     kb = PDFKnowledgeBase(

--- a/src/brew_oracle/utils/config.py
+++ b/src/brew_oracle/utils/config.py
@@ -7,7 +7,7 @@ class Settings(BaseSettings):
 
     PDF_PATH: str = Field(default="knowledge/pdfs")
 
-    EMBEDDER_ID: str = Field(default="all-MiniLM-L6-v2")
+    EMBEDDER_ID: str = Field(default="./models/all-MiniLM-L6-v2")
     EMBEDDER_DIM: int = Field(default=384)
 
     TOP_K: int = Field(default=20)


### PR DESCRIPTION
## Summary
- Use Settings to set SentenceTransformer embedder ID and dimensions
- Default to local model path and document how to change

## Testing
- `python -m py_compile src/brew_oracle/knowledge/pdf_kb.py src/brew_oracle/utils/config.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896200c8e08832ba035e20f40010f54