### PR TITLE
Add interactive question loop for Brew Oracle

### DIFF
--- a/src/brew_oracle/core/run.py
+++ b/src/brew_oracle/core/run.py
@@ -1,8 +1,27 @@
 from brew_oracle.orchestrator.brewing_orchestrator import BrewingOrchestrator
 
+
 def main():
     agent = BrewingOrchestrator()
-    agent.ask("O que você tem em sua base de conhecimento?")
+    print("Digite uma pergunta (ou 'exit' para sair):")
+    while True:
+        try:
+            question = input("> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            break
+        if question.lower() in {"exit", "quit"}:
+            break
+        if not question:
+            continue
+        text, refs = agent.ask_with_refs(question)
+        print(text)
+        if refs:
+            print("\nReferências:")
+            for ref in refs:
+                print(f"- {ref}")
+    print("Até logo!")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add interactive CLI loop to `brew_oracle.core.run`
- print agent responses and references until user exits

## Testing
- `PYTHONPATH=src python -m brew_oracle.core.run <<'EOF'
exit
EOF` *(fails: ModuleNotFoundError: No module named 'agno')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689622b70430832ba0af2670983b1900