### PR TITLE
feat: make chunking parameters configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ Ele responde **usando a base de conhecimento indexada**, **cita as fontes** e ma
 
     TOP_K=25
 
+    # Configuração do chunking
+    CHUNK_SIZE=2000
+    CHUNK_OVERLAP=300
+    NUM_DOCUMENTS=5
+
     # Gemini (AI Studio): https://aistudio.google.com/
     GOOGLE_API_KEY=coloque_sua_chave_aqui
     ```
@@ -179,6 +184,8 @@ Config padrão recomendada (boa relação custo/qualidade):
 
 Menos pontos → buscas mais rápidas; chunks maiores → contexto mais coeso.
 Para algo mais "cirúrgico", use 1000/150 e considere reranking.
+
+💡 Ajuste `CHUNK_SIZE`, `CHUNK_OVERLAP` e `NUM_DOCUMENTS` no `.env` para personalizar o chunking e o número de documentos retornados.
 
 ---
 

--- a/src/brew_oracle/knowledge/pdf_kb.py
+++ b/src/brew_oracle/knowledge/pdf_kb.py
@@ -24,13 +24,13 @@ def build_pdf_kb() -> PDFKnowledgeBase:
         ),
         reader=PDFReader(
             chunk=True,
-            chunk_size=2000, 
+            chunk_size=s.CHUNK_SIZE,
             chunking_strategy=RecursiveChunking(
-                chunk_size=2000,
-                overlap=300,
-                ),
+                chunk_size=s.CHUNK_SIZE,
+                overlap=s.CHUNK_OVERLAP,
+            ),
         ),
-        num_documents=5,
+        num_documents=s.NUM_DOCUMENTS,
     )
     return kb
 

--- a/src/brew_oracle/utils/config.py
+++ b/src/brew_oracle/utils/config.py
@@ -12,6 +12,10 @@ class Settings(BaseSettings):
 
     TOP_K: int = Field(default=20)
 
+    CHUNK_SIZE: int = Field(default=2000)
+    CHUNK_OVERLAP: int = Field(default=300)
+    NUM_DOCUMENTS: int = Field(default=5)
+
     GOOGLE_API_KEY: str | None = Field(default=None)
 
     model_config = SettingsConfigDict(


### PR DESCRIPTION
## Summary
- add `CHUNK_SIZE`, `CHUNK_OVERLAP`, and `NUM_DOCUMENTS` to settings
- use configurable chunking values when building the PDF knowledge base
- document chunking options in the README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68962f4f2e34832ba1aaa90e3cb63e6f