### PR TITLE
Add rerank option to BrewingOrchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Ele responde **usando a base de conhecimento indexada**, **cita as fontes** e ma
 
     ```bash
     pdm run python -m brew_oracle.core.run
+    # com rerank
+    pdm run python -m brew_oracle.core.run --rerank
     ```
 
 ---
@@ -164,6 +166,14 @@ self.agent = Agent(
 ## 🔍 Busca + Rerank (opcional, recomendado)
 
 Para melhorar a precisão: buscar `TOP_K` alto no Qdrant e reranquear com `cross-encoder/ms-marco-MiniLM-L-6-v2`.
+
+Ative direto no CLI:
+
+```bash
+pdm run python -m brew_oracle.core.run --rerank
+```
+
+Ou rode o script isolado:
 
 ```bash
 pdm run python -m brew_oracle.scripts.query_with_rerank

--- a/src/brew_oracle/core/run.py
+++ b/src/brew_oracle/core/run.py
@@ -1,8 +1,18 @@
+import argparse
+
 from brew_oracle.orchestrator.brewing_orchestrator import BrewingOrchestrator
 
 
 def main():
-    agent = BrewingOrchestrator()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--rerank",
+        action="store_true",
+        help="Reordena os resultados da busca com CrossEncoder",
+    )
+    args = parser.parse_args()
+
+    agent = BrewingOrchestrator(rerank=args.rerank)
     print("Digite uma pergunta (ou 'exit' para sair):")
     while True:
         try:

--- a/src/brew_oracle/orchestrator/brewing_orchestrator.py
+++ b/src/brew_oracle/orchestrator/brewing_orchestrator.py
@@ -5,11 +5,45 @@ from brew_oracle.knowledge.pdf_kb import build_pdf_kb
 from brew_oracle.utils.config import Settings
 
 class BrewingOrchestrator:
-    def __init__(self, kb=None, model=None):
+    def __init__(
+        self,
+        kb=None,
+        model=None,
+        *,
+        rerank: bool = False,
+        rerank_model_id: str = "cross-encoder/ms-marco-MiniLM-L-6-v2",
+        rerank_model_kwargs: dict | None = None,
+    ) -> None:
 
         self.kb = kb or build_pdf_kb()
         s = Settings()
         self.model = model or Gemini(id="gemini-2.0-flash", api_key=s.GOOGLE_API_KEY)
+
+        self.rerank = rerank
+        if self.rerank:
+            from sentence_transformers import CrossEncoder
+
+            self._cross_encoder = CrossEncoder(
+                rerank_model_id, **(rerank_model_kwargs or {})
+            )
+            original_search = self.kb.search
+
+            def _search(query: str, *args, **kwargs):
+                docs = original_search(query, *args, **kwargs)
+                pairs = [
+                    (query, getattr(doc, "content", getattr(doc, "text", "")))
+                    for doc in docs
+                ]
+                scores = self._cross_encoder.predict(pairs)
+                reranked_docs = [
+                    doc
+                    for doc, _ in sorted(
+                        zip(docs, scores), key=lambda x: x[1], reverse=True
+                    )
+                ]
+                return reranked_docs
+
+            self.kb.search = _search
 
         self.agent = Agent(
             name="BrewingOrchestrator",


### PR DESCRIPTION
## Summary
- add optional rerank with CrossEncoder to BrewingOrchestrator
- expose `--rerank` flag in CLI entrypoint
- document rerank usage in README

## Testing
- `python -m py_compile src/brew_oracle/orchestrator/brewing_orchestrator.py src/brew_oracle/core/run.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896328e02a8832b86f4c5bf0bab4a5f