### PR TITLE
feat: add hybrid dense/BM25 search support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ Ele responde **usando a base de conhecimento indexada**, **cita as fontes** e ma
 5. **Criar a collection no Qdrant**
 
     ```bash
-    pdm run python -m brew_oracle.scripts.create_collections
+    # com suporte a vetores esparsos (BM25)
+    pdm run python -m brew_oracle.scripts.create_collections --hybrid
     ```
 
 6. **Adicionar PDFs**
@@ -128,7 +129,7 @@ Ele responde **usando a base de conhecimento indexada**, **cita as fontes** e ma
 7. **Ingerir PDFs**
 
     ```bash
-    pdm run python -c "from brew_oracle.knowledge.pdf_kb import ingest_pdfs; ingest_pdfs()"
+    pdm run python -c "from brew_oracle.knowledge.pdf_kb import ingest_pdfs; ingest_pdfs(hybrid=True)"
     # Saída esperada: OK: 589 pontos na coleção 'brew_books'.
     ```
 
@@ -138,6 +139,8 @@ Ele responde **usando a base de conhecimento indexada**, **cita as fontes** e ma
     pdm run python -m brew_oracle.core.run
     # com rerank
     pdm run python -m brew_oracle.core.run --rerank
+    # com busca híbrida (denso + BM25)
+    pdm run python -m brew_oracle.core.run --hybrid
     ```
 
 ---
@@ -229,7 +232,6 @@ Aumente `TOP_K` (25–30) para bases médias e ative rerank para respostas mais 
 
 ## 🗺️ Roadmap
 
-- Consulta híbrida (denso + BM25) com fusion scoring
 - Rerank integrado ao orquestrador
 - Agente de Receitas (BeerXML → JSON → Qdrant)
 - UI (Streamlit / Discord / Telegram)

--- a/src/brew_oracle/core/run.py
+++ b/src/brew_oracle/core/run.py
@@ -10,9 +10,14 @@ def main():
         action="store_true",
         help="Reordena os resultados da busca com CrossEncoder",
     )
+    parser.add_argument(
+        "--hybrid",
+        action="store_true",
+        help="Combina busca densa e BM25 via fusion scoring",
+    )
     args = parser.parse_args()
 
-    agent = BrewingOrchestrator(rerank=args.rerank)
+    agent = BrewingOrchestrator(rerank=args.rerank, hybrid=args.hybrid)
     print("Digite uma pergunta (ou 'exit' para sair):")
     while True:
         try:

--- a/src/brew_oracle/knowledge/pdf_kb.py
+++ b/src/brew_oracle/knowledge/pdf_kb.py
@@ -7,12 +7,25 @@ from agno.embedder.sentence_transformer import SentenceTransformerEmbedder
 from agno.document.chunking.recursive import RecursiveChunking
 from brew_oracle.utils.config import Settings
 
+try:  # Optional imports for sparse vectors / hybrid search
+    from qdrant_client import models as qmodels
+    from qdrant_client.fastembed import SparseEncoder
+except Exception:  # pragma: no cover - modules are optional
+    qmodels = None
+    SparseEncoder = None
+
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-def build_pdf_kb() -> PDFKnowledgeBase:
+def build_pdf_kb(hybrid: bool = False) -> PDFKnowledgeBase:
     """Create and configure the PDF knowledge base.
+
+    Parameters
+    ----------
+    hybrid : bool, optional
+        When ``True`` also generates sparse BM25 vectors and enables
+        fusion scoring between dense and sparse results, by default ``False``.
 
     The knowledge base uses settings defined in :class:`Settings` to configure
     the embedder, vector database and PDF reader.
@@ -30,6 +43,7 @@ def build_pdf_kb() -> PDFKnowledgeBase:
         id=s.EMBEDDER_ID,
         dimensions=s.EMBEDDER_DIM,
     )
+    sparse_encoder = SparseEncoder() if hybrid and SparseEncoder else None
 
     kb = PDFKnowledgeBase(
         path=s.PDF_PATH,
@@ -37,6 +51,7 @@ def build_pdf_kb() -> PDFKnowledgeBase:
             collection=s.QDRANT_COLLECTION,
             url=s.QDRANT_URL,
             embedder=embedder,
+            sparse=sparse_encoder,
         ),
         reader=PDFReader(
             chunk=True,
@@ -48,9 +63,41 @@ def build_pdf_kb() -> PDFKnowledgeBase:
         ),
         num_documents=s.NUM_DOCUMENTS,
     )
+    if hybrid and qmodels is not None:
+        original_search = kb.search
+
+        def _fusion_search(query: str, top_k: int | None = None, *args, **kwargs):
+            top_k = top_k or s.TOP_K
+            dense_docs = original_search(query, top_k=top_k, *args, **kwargs)
+            if not SparseEncoder:
+                return dense_docs
+            sparse_query = SparseEncoder().encode_queries([query])[0]
+            sparse_docs = original_search(
+                query,
+                top_k=top_k,
+                sparse_vector=qmodels.SparseVector(
+                    indices=sparse_query.indices, values=sparse_query.values
+                ),
+            )
+            scores: dict[str, float] = {}
+            for rank, doc in enumerate(dense_docs):
+                doc_id = getattr(doc, "id", getattr(doc, "doc_id", str(rank)))
+                scores[doc_id] = scores.get(doc_id, 0.0) + 1 / (rank + 60)
+            for rank, doc in enumerate(sparse_docs):
+                doc_id = getattr(doc, "id", getattr(doc, "doc_id", str(rank)))
+                scores[doc_id] = scores.get(doc_id, 0.0) + 1 / (rank + 60)
+            fused_docs = {getattr(doc, "id", getattr(doc, "doc_id", str(i))): doc for i, doc in enumerate(dense_docs + sparse_docs)}
+            return [doc for doc, _ in sorted(
+                [(fused_docs[i], sc) for i, sc in scores.items()],
+                key=lambda x: x[1],
+                reverse=True,
+            )][:top_k]
+
+        kb.search = _fusion_search  # type: ignore[assignment]
+
     return kb
 
-def ingest_pdfs(upsert: bool = True) -> None:
+def ingest_pdfs(upsert: bool = True, hybrid: bool = False) -> None:
     """Load PDF files into the Qdrant collection.
 
     Parameters
@@ -58,12 +105,17 @@ def ingest_pdfs(upsert: bool = True) -> None:
     upsert : bool, optional
         If ``True`` (default), existing documents are updated during
         ingestion; otherwise, only new documents are added.
+    hybrid : bool, optional
+        Also create sparse BM25 vectors for hybrid search, by default ``False``.
     """
 
     s = Settings()
-    kb = build_pdf_kb()
+    kb = build_pdf_kb(hybrid=hybrid)
     logger.info("Iniciando ingestão dos arquivos - Pasta: '%s'.", s.PDF_PATH)
-    kb.load(upsert=upsert)
+    load_kwargs = {"upsert": upsert}
+    if hybrid:
+        load_kwargs["sparse"] = True
+    kb.load(**load_kwargs)
     from qdrant_client import QdrantClient
 
     c = QdrantClient(url=s.QDRANT_URL)

--- a/src/brew_oracle/orchestrator/brewing_orchestrator.py
+++ b/src/brew_oracle/orchestrator/brewing_orchestrator.py
@@ -13,9 +13,10 @@ class BrewingOrchestrator:
         rerank: bool = False,
         rerank_model_id: str = "cross-encoder/ms-marco-MiniLM-L-6-v2",
         rerank_model_kwargs: dict | None = None,
+        hybrid: bool = False,
     ) -> None:
 
-        self.kb = kb or build_pdf_kb()
+        self.kb = kb or build_pdf_kb(hybrid=hybrid)
         s = Settings()
         self.model = model or Gemini(id="gemini-2.0-flash", api_key=s.GOOGLE_API_KEY)
 

--- a/src/brew_oracle/scripts/create_collections.py
+++ b/src/brew_oracle/scripts/create_collections.py
@@ -1,8 +1,11 @@
+import argparse
+
 from qdrant_client import QdrantClient
-from qdrant_client.http.models import VectorParams, SparseVectorParams, Distance
+from qdrant_client.http.models import Distance, SparseVectorParams, VectorParams
 from brew_oracle.utils.config import Settings
 
-def main(force_recreate: bool = False):
+
+def main(force_recreate: bool = False, hybrid: bool = False):
     s = Settings()
     client = QdrantClient(url=s.QDRANT_URL)
 
@@ -10,16 +13,25 @@ def main(force_recreate: bool = False):
         client.delete_collection(s.QDRANT_COLLECTION)
 
     if not client.collection_exists(s.QDRANT_COLLECTION):
-        client.create_collection(
-            collection_name=s.QDRANT_COLLECTION,
-            vectors_config=VectorParams(size=s.EMBEDDER_DIM, distance=Distance.COSINE),
-            sparse_vectors_config={
-                "bm25_sparse": SparseVectorParams()
-            },
-        )
+        kwargs = {
+            "collection_name": s.QDRANT_COLLECTION,
+            "vectors_config": VectorParams(size=s.EMBEDDER_DIM, distance=Distance.COSINE),
+        }
+        if hybrid:
+            kwargs["sparse_vectors_config"] = {"bm25_sparse": SparseVectorParams()}
+        client.create_collection(**kwargs)
         print(f"✅ Coleção '{s.QDRANT_COLLECTION}' criada em {s.QDRANT_URL}")
     else:
         print(f"ℹ️ Coleção '{s.QDRANT_COLLECTION}' já existe.")
 
+
 if __name__ == "__main__":
-    main(force_recreate=False)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--force", action="store_true", help="Recria a coleção se existir")
+    parser.add_argument(
+        "--hybrid",
+        action="store_true",
+        help="Inclui configuração para vetores esparsos (BM25)",
+    )
+    args = parser.parse_args()
+    main(force_recreate=args.force, hybrid=args.hybrid)

--- a/src/brew_oracle/scripts/query_with_rerank.py
+++ b/src/brew_oracle/scripts/query_with_rerank.py
@@ -11,12 +11,17 @@ from brew_oracle.knowledge.pdf_kb import build_pdf_kb
 def main() -> None:
     parser = argparse.ArgumentParser(description="Query PDF KB with rerank")
     parser.add_argument("query", nargs="?", help="Pergunta a ser pesquisada")
+    parser.add_argument(
+        "--hybrid",
+        action="store_true",
+        help="Combina busca densa e BM25 via fusion scoring",
+    )
     args = parser.parse_args()
 
     query = args.query or input("Pergunta: ")
 
     s = Settings()
-    kb = build_pdf_kb()
+    kb = build_pdf_kb(hybrid=args.hybrid)
 
     docs = kb.search(query, top_k=s.TOP_K)
 


### PR DESCRIPTION
## Summary
- allow building/ingesting PDF KB with optional BM25 sparse vectors
- add hybrid search using fusion scoring for agent and scripts
- document hybrid configuration and collection creation options

## Testing
- `PYTHONPATH=src python -m brew_oracle.scripts.create_collections --hybrid` *(fails: No module named 'qdrant_client')*
- `PYTHONPATH=src python -m brew_oracle.core.run --hybrid` *(fails: No module named 'agno')*
- `PYTHONPATH=src python -m brew_oracle.scripts.query_with_rerank --hybrid "teste"` *(fails: No module named 'sentence_transformers')*

------
https://chatgpt.com/codex/tasks/task_e_689637318a74832bad1721427a0f746b