### PR TITLE
Align license and env example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Ele responde **usando a base de conhecimento indexada**, **cita as fontes** e ma
     EMBEDDER_ID=./models/all-MiniLM-L6-v2
     EMBEDDER_DIM=384
 
-    TOP_K=25
+    TOP_K=20
 
     # Configuração do chunking
     CHUNK_SIZE=2000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 dependencies = ["agno>=1.7.8", "qdrant-client>=1.15.1", "pdfplumber>=0.11.7", "python-dotenv>=1.1.1", "tqdm>=4.67.1", "sentence-transformers>=5.1.0", "xmltodict>=0.14.2", "pypdf>=5.9.0", "pydantic-settings>=2.10.1", "google-genai>=1.29.0", "fastembed>=0.3.4"]
 requires-python = "==3.13.*"
 readme = "README.md"
-license = {text = "MIT"}
+license = {file = "LICENSE"}
 
 [project.scripts]
 brew-oracle = "brew_oracle.core.run:main"


### PR DESCRIPTION
## Summary
- reference Apache-2.0 license file in project metadata
- correct README .env sample to use TOP_K=20

## Testing
- `ruff check .` *(fails: UP007/UP006 in create_collections.py)*
- `mypy src` *(fails: Unused "type: ignore" comment in brewing_orchestrator.py)*

------
https://chatgpt.com/codex/tasks/task_e_6896ab2218a0832b8ea0721cadbffa37