### PR TITLE
Add configurable Gemini model ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ Ele responde **usando a base de conhecimento indexada**, **cita as fontes** e ma
    CHUNK_SIZE=2000
    CHUNK_OVERLAP=300
    NUM_DOCUMENTS=5
-   
+
    GOOGLE_API_KEY=sua_chave_api_do_google
+   MODEL_ID=gemini-2.0-flash
    ```
 
 4. **Crie as Coleções no Qdrant**
@@ -144,9 +145,12 @@ pdm run test
 O agente principal (Gemini) consulta a base de conhecimento e cita as fontes ao usar dados específicos.
 
 ```python
+from brew_oracle.utils.config import Settings
+
+s = Settings()
 self.agent = Agent(
   name="BrewingOrchestrator",
-  model=Gemini(id="gemini-1.5-flash", api_key=...), # Note: Changed from gemini-2.0-flash to gemini-1.5-flash
+  model=Gemini(id=s.MODEL_ID, api_key=s.GOOGLE_API_KEY),
   knowledge=kb,                      # PDFKnowledgeBase
   search_knowledge=True,
   add_references=True,

--- a/src/brew_oracle/orchestrator/brewing_orchestrator.py
+++ b/src/brew_oracle/orchestrator/brewing_orchestrator.py
@@ -21,7 +21,7 @@ class BrewingOrchestrator:
         self.pdf_kb = build_pdf_kb(hybrid=hybrid)
         self.recipe_kb = build_recipe_kb(hybrid=hybrid)
         s = Settings()
-        self.model = model or Gemini(id="gemini-2.0-flash", api_key=s.GOOGLE_API_KEY)
+        self.model = model or Gemini(id=s.MODEL_ID, api_key=s.GOOGLE_API_KEY)
 
         self.rerank = rerank
         if self.rerank:

--- a/src/brew_oracle/utils/config.py
+++ b/src/brew_oracle/utils/config.py
@@ -24,6 +24,7 @@ class Settings(BaseSettings):
     NUM_DOCUMENTS: int = Field(default=5)
 
     GOOGLE_API_KEY: str | None = Field(default=None)
+    MODEL_ID: str = Field(default="gemini-2.0-flash")
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/tests/orchestrator/test_brewing_orchestrator.py
+++ b/tests/orchestrator/test_brewing_orchestrator.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -26,6 +27,24 @@ class TestBrewingOrchestrator(unittest.TestCase):
         mock_build_pdf_kb.assert_called_once_with(hybrid=False)
         mock_build_recipe_kb.assert_called_once_with(hybrid=False)
         mock_gemini.assert_called_once()
+
+    @patch("brew_oracle.orchestrator.brewing_orchestrator.build_pdf_kb")
+    @patch("brew_oracle.orchestrator.brewing_orchestrator.build_recipe_kb")
+    @patch("brew_oracle.orchestrator.brewing_orchestrator.Gemini")
+    def test_uses_configured_model_id(
+        self, mock_gemini, mock_build_recipe_kb, mock_build_pdf_kb
+    ):
+        mock_pdf_kb = MagicMock()
+        mock_build_pdf_kb.return_value = mock_pdf_kb
+        mock_recipe_kb = MagicMock()
+        mock_build_recipe_kb.return_value = mock_recipe_kb
+        mock_model = MagicMock()
+        mock_gemini.return_value = mock_model
+
+        with patch.dict(os.environ, {"MODEL_ID": "custom-model"}):
+            BrewingOrchestrator()
+
+        mock_gemini.assert_called_once_with(id="custom-model", api_key=None)
 
     @patch("brew_oracle.orchestrator.brewing_orchestrator.build_pdf_kb")
     @patch("brew_oracle.orchestrator.brewing_orchestrator.build_recipe_kb")


### PR DESCRIPTION
## Summary
- allow choosing Gemini model via new `MODEL_ID` setting
- wire BrewingOrchestrator to use `Settings().MODEL_ID`
- document `MODEL_ID` environment variable and update orchestrator snippet
- test orchestrator uses configured model ID

## Testing
- `python -m ruff check .`
- `PYTHONPATH=src python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'agno')*


------
https://chatgpt.com/codex/tasks/task_e_6897c959b058832ba73af02a7494b666