### PR TITLE
feat: weight and dedupe combined search results

### DIFF
--- a/src/brew_oracle/orchestrator/brewing_orchestrator.py
+++ b/src/brew_oracle/orchestrator/brewing_orchestrator.py
@@ -17,6 +17,8 @@ class BrewingOrchestrator:
         rerank_model_id: str = "cross-encoder/ms-marco-MiniLM-L-6-v2",
         rerank_model_kwargs: dict | None = None,
         hybrid: bool = False,
+        pdf_weight: float = 1.0,
+        recipe_weight: float = 1.0,
     ) -> None:
         self.pdf_kb = build_pdf_kb(hybrid=hybrid)
         self.recipe_kb = build_recipe_kb(hybrid=hybrid)
@@ -24,6 +26,8 @@ class BrewingOrchestrator:
         self.model = model or Gemini(id=s.MODEL_ID, api_key=s.GOOGLE_API_KEY)
 
         self.rerank = rerank
+        self.pdf_weight = pdf_weight
+        self.recipe_weight = recipe_weight
         if self.rerank:
             from sentence_transformers import CrossEncoder
 
@@ -32,22 +36,55 @@ class BrewingOrchestrator:
         def _combined_search(query: str, *args, **kwargs):
             pdf_docs = self.pdf_kb.search(query, *args, **kwargs)
             recipe_docs = self.recipe_kb.search(query, *args, **kwargs)
-            combined_docs = pdf_docs + recipe_docs
+
+            # Normalize metadata
+            for doc in [*pdf_docs, *recipe_docs]:
+                meta = getattr(doc, "meta_data", None)
+                if not isinstance(meta, dict):
+                    meta = getattr(doc, "metadata", None)
+                if not isinstance(meta, dict):
+                    meta = {}
+                setattr(doc, "meta_data", meta)
+
+            docs_with_origin = [(doc, "pdf") for doc in pdf_docs] + [
+                (doc, "recipe") for doc in recipe_docs
+            ]
+
+            seen: set[tuple[str, int]] = set()
+            deduped: list[tuple[object, str]] = []
+            for doc, origin in docs_with_origin:
+                meta = getattr(doc, "meta_data", {})
+                source = meta.get("source")
+                page = meta.get("page")
+                key = (source, page)
+                if source is not None and page is not None:
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                deduped.append((doc, origin))
 
             if self.rerank:
                 pairs = [
                     (query, getattr(doc, "content", getattr(doc, "text", "")))
-                    for doc in combined_docs
+                    for doc, _ in deduped
                 ]
                 scores = self._cross_encoder.predict(pairs)
+                weights = [
+                    self.pdf_weight if origin == "pdf" else self.recipe_weight
+                    for _, origin in deduped
+                ]
+                weighted_scores = [s * w for s, w in zip(scores, weights, strict=False)]
                 reranked_docs = [
                     doc
-                    for doc, _ in sorted(
-                        zip(combined_docs, scores, strict=False), key=lambda x: x[1], reverse=True
+                    for (_, (doc, _)) in sorted(
+                        zip(weighted_scores, deduped, strict=False),
+                        key=lambda x: x[0],
+                        reverse=True,
                     )
                 ]
                 return reranked_docs
-            return combined_docs
+
+            return [doc for doc, _ in deduped]
 
         self.agent = Agent(
             name="BrewingOrchestrator",

--- a/tests/orchestrator/test_brewing_orchestrator.py
+++ b/tests/orchestrator/test_brewing_orchestrator.py
@@ -161,6 +161,60 @@ class TestBrewingOrchestrator(unittest.TestCase):
     @patch("brew_oracle.orchestrator.brewing_orchestrator.build_pdf_kb")
     @patch("brew_oracle.orchestrator.brewing_orchestrator.build_recipe_kb")
     @patch("brew_oracle.orchestrator.brewing_orchestrator.Gemini")
+    def test_combined_search_deduplicates_and_normalizes(
+        self, mock_gemini, mock_build_recipe_kb, mock_build_pdf_kb
+    ):
+        mock_pdf_kb = MagicMock()
+        mock_recipe_kb = MagicMock()
+        mock_build_pdf_kb.return_value = mock_pdf_kb
+        mock_build_recipe_kb.return_value = mock_recipe_kb
+
+        doc1 = MagicMock(content="pdf_doc1", meta_data={"source": "s1", "page": 1})
+        doc2 = MagicMock(content="dup", metadata={"source": "s1", "page": 1})
+        mock_pdf_kb.search.return_value = [doc1, doc2]
+        recipe_doc = MagicMock(content="recipe_doc1")
+        mock_recipe_kb.search.return_value = [recipe_doc]
+
+        agent = BrewingOrchestrator()
+        docs = agent.agent.search_knowledge("test query")
+
+        self.assertEqual(len(docs), 2)
+        contents = {d.content for d in docs}
+        self.assertIn("pdf_doc1", contents)
+        self.assertIn("recipe_doc1", contents)
+        self.assertNotIn("dup", contents)
+
+    @patch("brew_oracle.orchestrator.brewing_orchestrator.build_pdf_kb")
+    @patch("brew_oracle.orchestrator.brewing_orchestrator.build_recipe_kb")
+    @patch("brew_oracle.orchestrator.brewing_orchestrator.Gemini")
+    @patch("sentence_transformers.CrossEncoder")
+    def test_rerank_respects_weights(
+        self, mock_cross_encoder, mock_gemini, mock_build_recipe_kb, mock_build_pdf_kb
+    ):
+        mock_pdf_kb = MagicMock()
+        mock_recipe_kb = MagicMock()
+        mock_build_pdf_kb.return_value = mock_pdf_kb
+        mock_build_recipe_kb.return_value = mock_recipe_kb
+
+        pdf_doc = MagicMock(content="pdf_doc", meta_data={"source": "s1", "page": 1})
+        recipe_doc = MagicMock(content="recipe_doc", meta_data={})
+        mock_pdf_kb.search.return_value = [pdf_doc]
+        mock_recipe_kb.search.return_value = [recipe_doc]
+
+        mock_encoder = MagicMock()
+        mock_cross_encoder.return_value = mock_encoder
+        mock_encoder.predict.return_value = [0.5, 0.5]
+
+        agent = BrewingOrchestrator(rerank=True, pdf_weight=1.0, recipe_weight=2.0)
+        docs = agent.agent.search_knowledge("test query")
+
+        self.assertEqual(docs[0].content, "recipe_doc")
+        mock_cross_encoder.assert_called_once()
+        mock_encoder.predict.assert_called_once()
+
+    @patch("brew_oracle.orchestrator.brewing_orchestrator.build_pdf_kb")
+    @patch("brew_oracle.orchestrator.brewing_orchestrator.build_recipe_kb")
+    @patch("brew_oracle.orchestrator.brewing_orchestrator.Gemini")
     def test_hybrid_parameter_passed_to_kbs(
         self, mock_gemini, mock_build_recipe_kb, mock_build_pdf_kb
     ):


### PR DESCRIPTION
## Summary
- normalize metadata and drop duplicate docs by source/page in combined search
- add weighting for pdf vs recipe docs before reranking
- cover deduplication and weighting in orchestrator tests

## Testing
- `PYTHONPATH=src pytest tests/orchestrator/test_brewing_orchestrator.py`

------
https://chatgpt.com/codex/tasks/task_e_6897f0843b50832b864ae3b71ac14558